### PR TITLE
Display RAM size in GB instead of MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,70 +61,105 @@ usage of LDAP, but should work for most cases without changes.
 
 ```shell
 $ fedcloud-vo-monitor --vo cloud.egi.eu
-[.] Checking VO cloud.egi.eu at 100IT
-[-] WARNING: VO cloud.egi.eu is not available at 100IT in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at 100IT in fedcloudclient
-[.] Checking VO cloud.egi.eu at BIFI
-[-] WARNING: VO cloud.egi.eu is not available at BIFI in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at BIFI in fedcloudclient
-[.] Checking VO cloud.egi.eu at CENI
-[-] WARNING: VO cloud.egi.eu is not available at CENI in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CENI in fedcloudclient
-[.] Checking VO cloud.egi.eu at CESGA
-[-] WARNING: VO cloud.egi.eu is not available at CESGA in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CESGA in fedcloudclient
-[.] Checking VO cloud.egi.eu at CESGA-CLOUD
-[-] WARNING: VO cloud.egi.eu is not available at CESGA-CLOUD in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CESGA-CLOUD in fedcloudclient
-[.] Checking VO cloud.egi.eu at CESNET-MCC
-[-] WARNING: VO cloud.egi.eu is not available at CESNET-MCC in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CESNET-MCC in fedcloudclient
-[.] Checking VO cloud.egi.eu at CETA-GRID
-[-] WARNING: VO cloud.egi.eu is not available at CETA-GRID in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CETA-GRID in fedcloudclient
-[.] Checking VO cloud.egi.eu at CLOUDIFIN
-[-] WARNING: VO cloud.egi.eu is not available at CLOUDIFIN in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CLOUDIFIN in fedcloudclient
-[.] Checking VO cloud.egi.eu at CSTCLOUD-EGI
-[-] WARNING: VO cloud.egi.eu is not available at CSTCLOUD-EGI in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CSTCLOUD-EGI in fedcloudclient
-[.] Checking VO cloud.egi.eu at CYFRONET-CLOUD
-[-] WARNING: VO cloud.egi.eu is not available at CYFRONET-CLOUD in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at CYFRONET-CLOUD in fedcloudclient
-[.] Checking VO cloud.egi.eu at DESY-CC
-[-] WARNING: VO cloud.egi.eu is not available at DESY-CC in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at DESY-CC in fedcloudclient
-[.] Checking VO cloud.egi.eu at GRNET-OPENSTACK
-[-] WARNING: VO cloud.egi.eu is not available at GRNET-OPENSTACK in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at GRNET-OPENSTACK in fedcloudclient
-[.] Checking VO cloud.egi.eu at GSI-LCG2
-[-] WARNING: VO cloud.egi.eu is not available at GSI-LCG2 in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at GSI-LCG2 in fedcloudclient
-[.] Checking VO cloud.egi.eu at IFCA-LCG2
-[-] WARNING: VO cloud.egi.eu is not available at IFCA-LCG2 in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at IFCA-LCG2 in fedcloudclient
-[.] Checking VO cloud.egi.eu at IISAS-FedCloud
-[+] Total VM instance(s) running in the resource provider = 2
+[.] Checking VO cloud.egi.eu at NCG-INGRID-PT
+[+] Total VM instance(s) running in the resource provider = 3
 Getting VMs information  [####################################]  100%
 [+] VM #0  --------------------------------------------------
-    instance name  = cloud-info-backup
-    instance id    = d4e00df3-cbf7-421e-bf9c-66470bb19441
+    instance name  = cloud-info
+    instance id    = 0d9d8c9b-a161-4b59-9ba6-7275e898c7fb
     status         = ACTIVE
-    ip address     = 192.168.10.170
-    flavor         = m1.large with 4 vCPU cores, 8192 of RAM and 30 GB of local disk
-    created at     = 2024-02-28T08:45:15Z
-    elapsed time   = 40 days, 3:14:07.603224
+    ip address     = 192.168.1.31
+    flavor         = svc1.m with 2 vCPU cores, 4 GB of RAM and 40 GB of local disk
+    created at     = 2024-06-24T06:25:30Z
+    elapsed time   = 14 days, 3:50:14.385004
+    user           = [REDACTED]
+[+] VM #1  --------------------------------------------------
+    instance name  = atrope
+    instance id    = d6815b91-599d-4c6a-8d55-a38243148838
+    status         = ACTIVE
+    ip address     = 192.168.1.250 194.210.120.242
+    flavor         = svc2.l with 8 vCPU cores, 8 GB of RAM and 40 GB of local disk
+    created at     = 2022-08-31T07:17:18Z
+    elapsed time   = 677 days, 2:58:26.385004
+    user           = [REDACTED]
+[-] WARNING The VM instance elapsed time exceed the max offset!
+[+] VM #2  --------------------------------------------------
+    instance name  = nsupdate
+    instance id    = 045ec1e7-b47a-4f18-9c9f-06cb30803955
+    status         = ACTIVE
+    ip address     = 192.168.1.71 194.210.120.90
+    flavor         = svc2.m with 4 vCPU cores, 4 GB of RAM and 40 GB of local disk
+    created at     = 2020-11-13T09:01:32Z
+    elapsed time   = 1333 days, 1:14:12.385004
+    user           = [REDACTED]
+[-] WARNING The VM instance elapsed time exceed the max offset!
+[+] Quota information:
+    ram (GB)       = 64
+    instances      = 10
+    cores          = 24
+    floating-ips   = 2
+    secgroup-rules = 100
+[-] WARNING: Less than 1 GB RAM per available CPU
+[-] WARNING: Less than 3 security groups per instance
+[-] WARNING: Less than 1 floating IPs per instance
+[.] Checking VO cloud.egi.eu at IISAS-FedCloud
+[+] Total VM instance(s) running in the resource provider = 5
+Getting VMs information  [####################################]  100%
+[+] VM #0  --------------------------------------------------
+    instance name  = atrope-test
+    instance id    = 5d56f0af-05aa-442a-8536-8667e9f81a82
+    status         = ACTIVE
+    ip address     = 192.168.10.9
+    flavor         = m1.large with 4 vCPU cores, 8 GB of RAM and 30 GB of local disk
+    created at     = 2024-06-24T15:03:27Z
+    elapsed time   = 13 days, 19:12:48.034861
     user           = [REDACTED]
     egi user       = [REDACTED]
     email          = [REDACTED]
 [+] VM #1  --------------------------------------------------
+    instance name  = iisas-im-site-wn-ab794604-f898-11ee-814a-b2e38e6a6a66
+    instance id    = 46ec6648-d364-4ca7-9480-5af64cda9e9c
+    status         = ACTIVE
+    ip address     = 192.168.10.53
+    flavor         = m1.large with 4 vCPU cores, 8 GB of RAM and 30 GB of local disk
+    created at     = 2024-04-12T06:48:32Z
+    elapsed time   = 87 days, 3:27:43.034861
+    user           = [REDACTED]
+    egi user       = [REDACTED]
+    email          = [REDACTED]
+    IM id          = [REDACTED]
+[+] VM #2  --------------------------------------------------
+    instance name  = iisas-im-site-wn-ab794604-f898-11ee-814a-b2e38e6a6a66
+    instance id    = 1beb4b53-d6e4-4e30-8046-222b4e82b806
+    status         = ACTIVE
+    ip address     = 192.168.10.72
+    flavor         = m1.large with 4 vCPU cores, 8 GB of RAM and 30 GB of local disk
+    created at     = 2024-04-12T06:48:30Z
+    elapsed time   = 87 days, 3:27:45.034861
+    user           = [REDACTED]
+    egi user       = [REDACTED]
+    email          = [REDACTED]
+    IM id          = [REDACTED]
+[+] VM #3  --------------------------------------------------
+    instance name  = iisas-im-site-front-a47d516a-f898-11ee-814a-b2e38e6a6a66
+    instance id    = 8e530674-d4a6-482c-974f-376eacbe609a
+    status         = ACTIVE
+    ip address     = 192.168.10.144 147.213.76.76
+    flavor         = m1.large with 4 vCPU cores, 8 GB of RAM and 30 GB of local disk
+    created at     = 2024-04-12T06:48:18Z
+    elapsed time   = 87 days, 3:27:57.034861
+    user           = [REDACTED]
+    egi user       = [REDACTED]
+    email          = [REDACTED]
+    IM id          = [REDACTED]
+[+] VM #4  --------------------------------------------------
     instance name  = dashboard
     instance id    = 8ef9fcce-19e4-41c6-ab03-d1730a924510
     status         = ACTIVE
-    ip address     = 192.168.10.69 xxx.xxx.xx.xxx
-    flavor         = m1.medium with 2 vCPU cores, 4096 of RAM and 20 GB of local disk
+    ip address     = 192.168.10.69 147.213.76.217
+    flavor         = m1.medium with 2 vCPU cores, 4 GB of RAM and 20 GB of local disk
     created at     = 2021-12-02T14:53:32Z
-    elapsed time   = 857 days, 21:05:50.603224
+    elapsed time   = 948 days, 19:22:43.034861
     user           = [REDACTED]
     egi user       = [REDACTED]
     email          = [REDACTED]
@@ -132,101 +167,11 @@ Getting VMs information  [####################################]  100%
 [+] Quota information:
     cores          = 20
     instances      = 10
-    ram            = 51200
+    ram (GB)       = 50
     floating-ips   = 10
     secgroup-rules = 100
+[-] WARNING: Less than 1 GB RAM per available CPU
 [-] WARNING: Less than 3 security groups per instance
-[.] Checking VO cloud.egi.eu at ILIFU-UCT
-[-] WARNING: VO cloud.egi.eu is not available at ILIFU-UCT in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at ILIFU-UCT in fedcloudclient
-[.] Checking VO cloud.egi.eu at IN2P3-IRES
-[-] WARNING: VO cloud.egi.eu is not available at IN2P3-IRES in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at IN2P3-IRES in fedcloudclient
-[.] Checking VO cloud.egi.eu at INFN-CLOUD-BARI
-[-] WARNING: VO cloud.egi.eu is not available at INFN-CLOUD-BARI in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at INFN-CLOUD-BARI in fedcloudclient
-[.] Checking VO cloud.egi.eu at INFN-CLOUD-CNAF
-[-] WARNING: VO cloud.egi.eu is not available at INFN-CLOUD-CNAF in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at INFN-CLOUD-CNAF in fedcloudclient
-[.] Checking VO cloud.egi.eu at NCG-INGRID-PT
-[-] WARNING: VO cloud.egi.eu is not available at NCG-INGRID-PT in AppDB
-[+] Total VM instance(s) running in the resource provider = 4
-Getting VMs information  [------------------------------------]    0%WARNING: Unable to get user list: The request you have made requires authentication. (HTTP 401) (Request-ID: req-5ac539f1-7869-4fd8-9483-8b9eb704d725)
-
-Getting VMs information  [####################################]  100%
-[+] VM #0  --------------------------------------------------
-    instance name  = test
-    instance id    = d2431967-a519-47e4-8d8c-209727840233
-    status         = ACTIVE
-    ip address     = 192.168.1.233
-    flavor         = svc1.m with 2 vCPU cores, 4096 of RAM and 40 GB of local disk
-    created at     = 2024-02-29T09:43:01Z
-    elapsed time   = 39 days, 2:17:01.266584
-    user           = [REDACTED]
-[+] VM #1  --------------------------------------------------
-    instance name  = cloud-info
-    instance id    = 9f8c17b4-5503-42ac-af3d-6ed0c9dea9c7
-    status         = ACTIVE
-    ip address     = 192.168.1.3
-    flavor         = svc1.m with 2 vCPU cores, 4096 of RAM and 40 GB of local disk
-    created at     = 2024-02-28T14:39:08Z
-    elapsed time   = 39 days, 21:20:54.266584
-    user           = [REDACTED]
-[+] VM #2  --------------------------------------------------
-    instance name  = atrope
-    instance id    = d6815b91-599d-4c6a-8d55-a38243148838
-    status         = ACTIVE
-    ip address     = 192.168.1.250 xxx.xxx.xxx.xxx
-    flavor         = svc2.l with 8 vCPU cores, 8192 of RAM and 40 GB of local disk
-    created at     = 2022-08-31T07:17:18Z
-    elapsed time   = 586 days, 4:42:44.266584
-    user           = [REDACTED]
-[-] WARNING The VM instance elapsed time exceed the max offset!
-[+] VM #3  --------------------------------------------------
-    instance name  = nsupdate
-    instance id    = 045ec1e7-b47a-4f18-9c9f-06cb30803955
-    status         = ACTIVE
-    ip address     = 192.168.1.71 xxx.xxx.xxx.xxx
-    flavor         = svc2.m with 4 vCPU cores, 4096 of RAM and 40 GB of local disk
-    created at     = 2020-11-13T09:01:32Z
-    elapsed time   = 1242 days, 2:58:30.266584
-    user           = [REDACTED]
-[-] WARNING The VM instance elapsed time exceed the max offset!
-[+] Quota information:
-    ram            = 65536
-    instances      = 10
-    cores          = 24
-    floating-ips   = 2
-    secgroup-rules = 100
-[-] WARNING: Less than 3 security groups per instance
-[-] WARNING: Less than 1 floating IPs per instance
-[.] Checking VO cloud.egi.eu at SCAI
-[-] WARNING: VO cloud.egi.eu is not available at SCAI in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at SCAI in fedcloudclient
-[.] Checking VO cloud.egi.eu at TR-FC1-ULAKBIM
-[-] WARNING: VO cloud.egi.eu is not available at TR-FC1-ULAKBIM in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at TR-FC1-ULAKBIM in fedcloudclient
-[.] Checking VO cloud.egi.eu at UA-BITP
-[-] WARNING: VO cloud.egi.eu is not available at UA-BITP in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at UA-BITP in fedcloudclient
-[.] Checking VO cloud.egi.eu at UNIV-LILLE
-[-] WARNING: VO cloud.egi.eu is not available at UNIV-LILLE in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at UNIV-LILLE in fedcloudclient
-[.] Checking VO cloud.egi.eu at UPV-GRyCAP
-[-] WARNING: VO cloud.egi.eu is not available at UPV-GRyCAP in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at UPV-GRyCAP in fedcloudclient
-[.] Checking VO cloud.egi.eu at WALTON-CLOUD
-[-] WARNING: VO cloud.egi.eu is not available at WALTON-CLOUD in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at WALTON-CLOUD in fedcloudclient
-[.] Checking VO cloud.egi.eu at fedcloud.srce.hr
-[-] WARNING: VO cloud.egi.eu is not available at fedcloud.srce.hr in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at fedcloud.srce.hr in fedcloudclient
-[.] Checking VO cloud.egi.eu at EODC
-[-] WARNING: VO cloud.egi.eu is not available at EODC in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at EODC in fedcloudclient
-[.] Checking VO cloud.egi.eu at ELKH-CLOUD
-[-] WARNING: VO cloud.egi.eu is not available at ELKH-CLOUD in AppDB
-[-] WARNING: VO cloud.egi.eu is not available at ELKH-CLOUD in fedcloudclient
 ```
 
 ## Useful links

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -214,7 +214,7 @@ class SiteMonitor:
         for r in quota:
             if r["Resource"] in resources:
                 if r["Resource"] == "ram":
-                    quota_info[r["Resource"] + " (GB)"] = int(r["Limit"]/1024)
+                    quota_info[r["Resource"] + " (GB)"] = int(r["Limit"] / 1024)
                 else:
                     quota_info[r["Resource"]] = r["Limit"]
         for k, v in quota_info.items():

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -142,8 +142,8 @@ class SiteMonitor:
             output.append(
                 (
                     "flavor",
-                    f"{flv['Name']} with {flv['VCPUs']} vCPU cores, {flv['RAM']} "
-                    f"of RAM and {flv['Disk']} GB of local disk",
+                    f"{flv['Name']} with {flv['VCPUs']} vCPU cores, {int(flv['RAM']/1024)} "
+                    f"GB of RAM and {flv['Disk']} GB of local disk",
                 )
             )
         output.append(("created at", vm_info["created_at"]))
@@ -213,13 +213,16 @@ class SiteMonitor:
         quota_info = {}
         for r in quota:
             if r["Resource"] in resources:
-                quota_info[r["Resource"]] = r["Limit"]
+                if r["Resource"] == "ram":
+                    quota_info[r["Resource"] + " (GB)"] = int(r["Limit"]/1024)
+                else:
+                    quota_info[r["Resource"]] = r["Limit"]
         for k, v in quota_info.items():
             click.echo(f"    {k:<14} = {v}")
         # checks on quota
         if quota_info.get("ram", 1) / quota_info.get("cpu", 1) < self.min_ram_cpu_ratio:
             click.secho(
-                f"[-] WARNING: Less than {self.min_ram_cpu_ratio} RAM per available CPU",
+                f"[-] WARNING: Less than {int(self.min_ram_cpu_ratio/1024)} GB RAM per available CPU",
                 fg="yellow",
             )
         if (


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

The default RAM size in OpenStack is MB but it is more convenient to have this converted to GB

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :**
