### PR TITLE
Add image name to output

### DIFF
--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -81,8 +81,46 @@ class SiteMonitor:
             return {}
         return self.flavors[flavor_name]
 
+    def get_vm_image_volume_show(self, volume_id):
+        try:
+            cmd = ("volume", "show", volume_id, "--format", "json")
+            result = self._run_command(cmd)
+            if ('volume_image_metadata' in result) and \
+               ('sl:osname' and 'sl:osversion' in result['volume_image_metadata']):
+                return result['volume_image_metadata']['sl:osname'] + \
+                       result['volume_image_metadata']['sl:osversion']
+            else:
+                return "image name not found"
+        except SiteMonitorException as err:
+            return "image name not found"
+
+    def get_vm_image_server_show(self, vm_id):
+        try:
+            cmd = ("server", "show", vm_id, "--format", "json")
+            result = self._run_command(cmd)
+            if len(result['attached_volumes']) > 0:
+                return self.get_vm_image_volume_show(result['attached_volumes'][0]['id'])
+            else:
+                return "image name not found"
+        except SiteMonitorException as err:
+            return "image name not found"
+
+    def get_vm_image(self, vm_id, image_name, image_id):
+        if len(image_name) > 0:
+            return image_name
+        else:
+            try:
+                cmd = ("image", "show", image_id, "--format", "json")
+                result = self._run_command(cmd)
+                if 'sl:osname' and 'sl:osversion' in result['properties']:
+                    return result['properties']['sl:osname'] + result['properties']['sl:osversion']
+                else:
+                    return self.get_vm_image_server_show(vm_id)
+            except SiteMonitorException as err:
+                return self.get_vm_image_server_show(vm_id)
+
     def get_vms(self):
-        command = ("server", "list")
+        command = ("server", "list", "--long")
         return self._run_command(command)
 
     def get_vm(self, vm):
@@ -146,6 +184,7 @@ class SiteMonitor:
                     f"GB of RAM and {flv['Disk']} GB of local disk",
                 )
             )
+        output.append(("image: ", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"])))
         output.append(("created at", vm_info["created_at"]))
         output.append(("elapsed time", elapsed))
         user_id = vm_info["user_id"]

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -85,24 +85,29 @@ class SiteMonitor:
         try:
             cmd = ("volume", "show", volume_id, "--format", "json")
             result = self._run_command(cmd)
-            if ('volume_image_metadata' in result) and \
-               ('sl:osname' and 'sl:osversion' in result['volume_image_metadata']):
-                return result['volume_image_metadata']['sl:osname'] + \
-                       result['volume_image_metadata']['sl:osversion']
+            if ("volume_image_metadata" in result) and (
+                "sl:osname" and "sl:osversion" in result["volume_image_metadata"]
+            ):
+                return (
+                    result["volume_image_metadata"]["sl:osname"]
+                    + result["volume_image_metadata"]["sl:osversion"]
+                )
             else:
                 return "image name not found"
-        except SiteMonitorException as err:
+        except SiteMonitorException:
             return "image name not found"
 
     def get_vm_image_server_show(self, vm_id):
         try:
             cmd = ("server", "show", vm_id, "--format", "json")
             result = self._run_command(cmd)
-            if len(result['attached_volumes']) > 0:
-                return self.get_vm_image_volume_show(result['attached_volumes'][0]['id'])
+            if len(result["attached_volumes"]) > 0:
+                return self.get_vm_image_volume_show(
+                    result["attached_volumes"][0]["id"]
+                )
             else:
                 return "image name not found"
-        except SiteMonitorException as err:
+        except SiteMonitorException:
             return "image name not found"
 
     def get_vm_image(self, vm_id, image_name, image_id):
@@ -112,11 +117,14 @@ class SiteMonitor:
             try:
                 cmd = ("image", "show", image_id, "--format", "json")
                 result = self._run_command(cmd)
-                if 'sl:osname' and 'sl:osversion' in result['properties']:
-                    return result['properties']['sl:osname'] + result['properties']['sl:osversion']
+                if "sl:osname" and "sl:osversion" in result["properties"]:
+                    return (
+                        result["properties"]["sl:osname"]
+                        + result["properties"]["sl:osversion"]
+                    )
                 else:
                     return self.get_vm_image_server_show(vm_id)
-            except SiteMonitorException as err:
+            except SiteMonitorException:
                 return self.get_vm_image_server_show(vm_id)
 
     def get_vms(self):
@@ -184,7 +192,9 @@ class SiteMonitor:
                     f"GB of RAM and {flv['Disk']} GB of local disk",
                 )
             )
-        output.append(("image: ", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"])))
+        output.append(
+            ("image: ", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"]))
+        )
         output.append(("created at", vm_info["created_at"]))
         output.append(("elapsed time", elapsed))
         user_id = vm_info["user_id"]

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -193,7 +193,7 @@ class SiteMonitor:
                 )
             )
         output.append(
-            ("image: ", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"]))
+            ("VM image", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"]))
         )
         output.append(("created at", vm_info["created_at"]))
         output.append(("elapsed time", elapsed))


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

Use the image name printed below if available:
```bash
# note: need "--long" since "Image ID" is not available without it
openstack server list --long -c "ID" -c "Name" -c "Image Name" -c "Image ID"
```
If not, try:
```bash
# get "sl:osname" and "sl:osversion" from "properties" when available
openstack image show <image-id>
```

If not, try:
```bash
# get attached volumes
openstack server show <vm-id>
# get "sl:osname" and "sl:osversion" from "volume_image_metadata" when available
openstack volume show <volume-id>
```

Am I missing more options?

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :** https://github.com/EGI-Federation/fedcloud-vm-monitoring/issues/15
