### PR TITLE
Adding checks for CUPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ You can tune the behavior with the following parameters:
   triggering deletion (default 90 days).
 - `--show-quotas BOOLEAN`: whether to show quotas for the VO or not (default:
   `True`)
+- `--check-ssh BOOLEAN`: Check SSH version on target VMs (default: `False`)
+- `--check-cups BOOLEAN`: Check whether TCP/UDP port 631 is accessible
+  (default: `False`)
 
 If you have access to
 [Check-in LDAP](https://docs.egi.eu/users/aai/check-in/vos/#ldap) for VO

--- a/fedcloud_vm_monitoring/cli.py
+++ b/fedcloud_vm_monitoring/cli.py
@@ -100,7 +100,7 @@ def main(
     for s in sites:
         click.secho(f"[.] Checking VO {vo} at {s}", fg="blue", bold=True)
         site_monitor = SiteMonitor(
-            s, vo, access_token, max_days, check_ssh, check_cups, ldap_config)
+            s, vo, access_token, max_days, check_ssh, check_cups, ldap_config
         )
         try:
             site_monitor.vm_monitor(delete)

--- a/fedcloud_vm_monitoring/cli.py
+++ b/fedcloud_vm_monitoring/cli.py
@@ -99,7 +99,9 @@ def main(
     sites = [site] if site else set(appdb_sites + fedcloudclient_sites)
     for s in sites:
         click.secho(f"[.] Checking VO {vo} at {s}", fg="blue", bold=True)
-        site_monitor = SiteMonitor(s, vo, access_token, max_days, check_ssh, check_cups, ldap_config)
+        site_monitor = SiteMonitor(
+            s, vo, access_token, max_days, check_ssh, check_cups, ldap_config)
+        )
         try:
             site_monitor.vm_monitor(delete)
         except SiteMonitorException as e:

--- a/fedcloud_vm_monitoring/cli.py
+++ b/fedcloud_vm_monitoring/cli.py
@@ -36,6 +36,18 @@ from fedcloudclient.sites import list_sites
     show_default=True,
 )
 @click.option(
+    "--check-ssh",
+    default=False,
+    help="Check SSH version on target VMs",
+    show_default=True,
+)
+@click.option(
+    "--check-cups",
+    default=False,
+    help="Check whether TCP/UDP port 631 is accessible",
+    show_default=True,
+)
+@click.option(
     "--ldap-server",
     default="ldaps://ldap.aai.egi.eu:636",
     help="LDAP server for VO membership",
@@ -62,6 +74,8 @@ def main(
     max_days,
     delete,
     show_quotas,
+    check_ssh,
+    check_cups,
     ldap_server,
     ldap_base_dn,
     ldap_user,
@@ -85,7 +99,7 @@ def main(
     sites = [site] if site else set(appdb_sites + fedcloudclient_sites)
     for s in sites:
         click.secho(f"[.] Checking VO {vo} at {s}", fg="blue", bold=True)
-        site_monitor = SiteMonitor(s, vo, access_token, max_days, ldap_config)
+        site_monitor = SiteMonitor(s, vo, access_token, max_days, check_ssh, check_cups, ldap_config)
         try:
             site_monitor.vm_monitor(delete)
         except SiteMonitorException as e:

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -262,6 +262,9 @@ class SiteMonitor:
         return returncode, stdout, stderr
 
     def check_CUPS(self, ip_addresses):
+        returncode_ncat, stdout_ncat, stderr_ncat = self._run_shell_command("which ncat")
+        if returncode_ncat != 0:
+            return "ncat ( https://nmap.org/ncat ) is not installed"
         public_ip = self.get_public_ip(ip_addresses)
         if len(public_ip) > 0:
             returncode_tcp, stdout_tcp, stderr_tcp = self.check_open_port(public_ip, 631, "tcp")
@@ -269,7 +272,7 @@ class SiteMonitor:
             if returncode_tcp == 0 or returncode_upd == 0:
                 return "WARNING: CUPS port is open"
             elif returncode_tcp == 1 and returncode_upd == 1:
-                return "CUPS port is not open"
+                return "CUPS port is closed"
             else:
                 return "Error checking CUPS port: " + returncode + stdout + stderr
         else:

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -284,9 +284,10 @@ class SiteMonitor:
             elif returncode_tcp == 1 and returncode_upd == 1:
                 return "CUPS port is closed"
             else:
-                return "Error checking CUPS port: " +
-                       "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}" +
+                return ("Error checking CUPS port: "
+                       "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}"
                        "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}"
+                       )
         else:
             return "No public IP available to check CUPs version"
 

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -299,7 +299,6 @@ class SiteMonitor:
         for net, addrs in vm["Networks"].items():
             vm_ips.extend(addrs)
         sshd_version = self.get_sshd_version(vm_ips)
-        CUPS_check = self.check_CUPS(vm_ips)
         created = parse(vm_info["created_at"])
         elapsed = self.now - created
         output = [

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -284,10 +284,11 @@ class SiteMonitor:
             elif returncode_tcp == 1 and returncode_upd == 1:
                 return "CUPS port is closed"
             else:
-                return ("Error checking CUPS port: "
-                       "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}"
-                       "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}"
-                       )
+                return (
+                    "Error checking CUPS port: "
+                    "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}"
+                    "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}"
+                )
         else:
             return "No public IP available to check CUPs version"
 

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -284,7 +284,9 @@ class SiteMonitor:
             elif returncode_tcp == 1 and returncode_upd == 1:
                 return "CUPS port is closed"
             else:
-                return "Error checking CUPS port: " + returncode + stdout + stderr
+                return "Error checking CUPS port: " +
+                       "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}" +
+                       "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}"
         else:
             return "No public IP available to check CUPs version"
 

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -250,10 +250,7 @@ class SiteMonitor:
             capture_output=True,
             text=True,
         )
-        returncode = completed.returncode
-        stdout = completed.stdout
-        stderr = completed.stderr
-        return returncode, stdout, stderr
+        return completed.returncode, completed.stdout, completed.stderr
 
     def check_open_port(self, ip, port, protocol):
         if protocol == "tcp":

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -285,9 +285,9 @@ class SiteMonitor:
                 return "CUPS port is closed"
             else:
                 return (
-                    "Error checking CUPS port: "
-                    "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}"
-                    "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}"
+                    "Error checking CUPS port. "
+                    "TCP return code: {returncode_tcp}, stdout: {stdout_tcp}, stderr: {stderr_tcp}. "
+                    "UDP return code: {returncode_upd}, stdout: {stdout_upd}, stderr: {stderr_upd}."
                 )
         else:
             return "No public IP available to check CUPs version"

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -28,11 +28,13 @@ class SiteMonitor:
     min_secgroup_instance_ratio = 3
     min_ip_instance_ratio = 1
 
-    def __init__(self, site, vo, token, max_days, ldap_config={}):
+    def __init__(self, site, vo, token, max_days, check_ssh, check_cups, ldap_config={}):
         self.site = site
         self.vo = vo
         self.token = token
         self.max_days = max_days
+        self.check_ssh = check_ssh
+        self.check_cups = check_cups
         self.ldap_config = ldap_config
         self.flavors = {}
         self.users = defaultdict(lambda: {})
@@ -293,9 +295,13 @@ class SiteMonitor:
             ("instance id", vm["ID"]),
             ("status", click.style(vm["Status"], fg=self.color_maps[vm["Status"]])),
             ("ip address", " ".join(vm_ips)),
-            ("SSH version", sshd_version),
-            ("CUPS", CUPS_check),
         ]
+        if self.check_ssh:
+            sshd_version = self.get_sshd_version(vm_ips)
+            output.append(("SSH version", sshd_version))
+        if self.check_cups:
+            CUPS_check = self.check_CUPS(vm_ips)
+            output.append(("CUPS", CUPS_check))
         if flv:
             output.append(
                 (

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -1,6 +1,7 @@
 """Monitor VM instances running in the provider"""
 
 import ipaddress
+import subprocess
 from collections import defaultdict
 from datetime import datetime, timezone
 
@@ -12,7 +13,6 @@ from fedcloudclient.openstack import fedcloud_openstack
 from fedcloudclient.sites import find_endpoint_and_project_id
 from ldap3.core.exceptions import LDAPException
 from paramiko import SSHException
-import subprocess
 
 
 class SiteMonitorException(Exception):
@@ -28,7 +28,9 @@ class SiteMonitor:
     min_secgroup_instance_ratio = 3
     min_ip_instance_ratio = 1
 
-    def __init__(self, site, vo, token, max_days, check_ssh, check_cups, ldap_config={}):
+    def __init__(
+        self, site, vo, token, max_days, check_ssh, check_cups, ldap_config={}
+    ):
         self.site = site
         self.vo = vo
         self.token = token
@@ -242,16 +244,16 @@ class SiteMonitor:
             return "No public IP available to check SSH version."
 
     def _run_shell_command(self, command):
-       completed = subprocess.run(
-           command,
-           shell=True,
-           capture_output=True,
-           text=True,
-       )
-       returncode = completed.returncode
-       stdout = completed.stdout
-       stderr = completed.stderr
-       return returncode, stdout, stderr
+        completed = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+        return returncode, stdout, stderr
 
     def check_open_port(self, ip, port, protocol):
         if protocol == "tcp":
@@ -264,13 +266,19 @@ class SiteMonitor:
         return returncode, stdout, stderr
 
     def check_CUPS(self, ip_addresses):
-        returncode_ncat, stdout_ncat, stderr_ncat = self._run_shell_command("which ncat")
+        returncode_ncat, stdout_ncat, stderr_ncat = self._run_shell_command(
+            "which ncat"
+        )
         if returncode_ncat != 0:
             return "ncat ( https://nmap.org/ncat ) is not installed"
         public_ip = self.get_public_ip(ip_addresses)
         if len(public_ip) > 0:
-            returncode_tcp, stdout_tcp, stderr_tcp = self.check_open_port(public_ip, 631, "tcp")
-            returncode_upd, stdout_upd, stderr_upd = self.check_open_port(public_ip, 631, "udp")
+            returncode_tcp, stdout_tcp, stderr_tcp = self.check_open_port(
+                public_ip, 631, "tcp"
+            )
+            returncode_upd, stdout_upd, stderr_upd = self.check_open_port(
+                public_ip, 631, "udp"
+            )
             if returncode_tcp == 0 or returncode_upd == 0:
                 return "WARNING: CUPS port is open"
             elif returncode_tcp == 1 and returncode_upd == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fedcloud-vm-monitoring"
-version = "0.2.0"
+version = "0.2.1"
 description = "Monitoring fedcloud VMs and sites"
 authors = ["Giuseppe La Rocca <giuseppe.larocca@egi.eu>",
            "Enol Fernandez <enol.fernandez@egi.eu>"]


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

This PR runs the following checks with [ncat](https://nmap.org/ncat/) on VMs with public IPs:

```bash
# TCP check
ncat --nodns -z {ip} {port}

# UDP check
ncat --udp --nodns --idle-timeout 3s {ip} {port}
```

Note that checking accessible UPD ports is not as easy. [1]

Although these checks are not comprehensive, it may still be useful to confirm whether further checks are required.

[1] https://serverfault.com/questions/416205/testing-udp-port-connectivity

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :**
