### PR TITLE
Add usage to quota reporting

### DIFF
--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -390,13 +390,18 @@ class SiteMonitor:
             if r["Resource"] in resources:
                 if r["Resource"] == "ram":
                     quota_info["ram (GB)"] = {
-                                "In Use": int(r["In Use"] / 1024),
-                                "Limit": int(r["Limit"] / 1024)
-                            }
+                        "In Use": int(r["In Use"] / 1024),
+                        "Limit": int(r["Limit"] / 1024)
+                    }
                 else:
                     quota_info[r["Resource"]] = {"In Use": r["In Use"], "Limit": r["Limit"]}
         for k, v in quota_info.items():
-            click.echo(f"    {k:<14} = {v}")
+            click.echo("    {:<14} = Limit: {:>3}, Used: {:>3} ({}%)".format(
+                k,
+                v["Limit"],
+                v["In Use"],
+                round(v["In Use"]/v["Limit"]*100)
+            ))
         # checks on quota
         if quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1) < self.min_ram_cpu_ratio:
             click.secho(

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -370,7 +370,7 @@ class SiteMonitor:
         return endpoint is not None
 
     def get_quota(self):
-        command = ("quota", "show")
+        command = ("quota", "show", "--usage")
         return self._run_command(command, do_raise=False)
 
     def show_quotas(self):

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -391,28 +391,32 @@ class SiteMonitor:
                 if r["Resource"] == "ram":
                     quota_info["ram (GB)"] = {
                         "In Use": int(r["In Use"] / 1024),
-                        "Limit": int(r["Limit"] / 1024)
+                        "Limit": int(r["Limit"] / 1024),
                     }
                 else:
-                    quota_info[r["Resource"]] = {"In Use": r["In Use"], "Limit": r["Limit"]}
+                    quota_info[r["Resource"]] = {
+                        "In Use": r["In Use"],
+                        "Limit": r["Limit"],
+                    }
         for k, v in quota_info.items():
-            click.echo("    {:<14} = Limit: {:>3}, Used: {:>3} ({}%)".format(
-                k,
-                v["Limit"],
-                v["In Use"],
-                round(v["In Use"]/v["Limit"]*100)
-            ))
+            click.echo(
+                "    {:<14} = Limit: {:>3}, Used: {:>3} ({}%)".format(
+                    k, v["Limit"], v["In Use"], round(v["In Use"] / v["Limit"] * 100)
+                )
+            )
         # checks on quota
         if (
-            quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1)
-            < self.min_ram_cpu_ratio:
+            quota_info.get("ram (GB)").get("Limit", 1)
+            / quota_info.get("cores").get("Limit", 1)
+            < self.min_ram_cpu_ratio
         ):
             click.secho(
                 f"[-] WARNING: Less than {self.min_ram_cpu_ratio} GB RAM per available CPU",
                 fg="yellow",
             )
         if (
-            quota_info.get("secgroups").get("Limit", 1) / quota_info.get("instances").get("Limit", 1)
+            quota_info.get("secgroups").get("Limit", 1)
+            / quota_info.get("instances").get("Limit", 1)
             < self.min_secgroup_instance_ratio
         ):
             click.secho(
@@ -420,7 +424,8 @@ class SiteMonitor:
                 fg="yellow",
             )
         if (
-            quota_info.get("floating-ips").get("Limit", 1) / quota_info.get("instances").get("Limit", 1)
+            quota_info.get("floating-ips").get("Limit", 1)
+            / quota_info.get("instances").get("Limit", 1)
             < self.min_ip_instance_ratio
         ):
             click.secho(

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -389,19 +389,22 @@ class SiteMonitor:
         for r in quota:
             if r["Resource"] in resources:
                 if r["Resource"] == "ram":
-                    quota_info[r["Resource"] + " (GB)"] = int(r["Limit"] / 1024)
+                    quota_info["ram (GB)"] = {
+                                "In Use": int(r["In Use"] / 1024),
+                                "Limit": int(r["Limit"] / 1024)
+                            }
                 else:
-                    quota_info[r["Resource"]] = r["Limit"]
+                    quota_info[r["Resource"]] = {"In Use": r["In Use"], "Limit": r["Limit"]}
         for k, v in quota_info.items():
             click.echo(f"    {k:<14} = {v}")
         # checks on quota
-        if quota_info.get("ram", 1) / quota_info.get("cpu", 1) < self.min_ram_cpu_ratio:
+        if quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1) < self.min_ram_cpu_ratio:
             click.secho(
                 f"[-] WARNING: Less than {int(self.min_ram_cpu_ratio/1024)} GB RAM per available CPU",
                 fg="yellow",
             )
         if (
-            quota_info.get("secgroup", 1) / quota_info.get("instances", 1)
+            quota_info.get("secgroups").get("Limit", 1) / quota_info.get("instances").get("Limit", 1)
             < self.min_secgroup_instance_ratio
         ):
             click.secho(
@@ -409,7 +412,7 @@ class SiteMonitor:
                 fg="yellow",
             )
         if (
-            quota_info.get("floating-ips", 1) / quota_info.get("instances", 1)
+            quota_info.get("floating-ips").get("Limit", 1) / quota_info.get("instances").get("Limit", 1)
             < self.min_ip_instance_ratio
         ):
             click.secho(

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -24,7 +24,7 @@ class SiteMonitor:
 
     color_maps = defaultdict(lambda: "red", ACTIVE="green", BUILD="yellow")
     # at least 1GB per core
-    min_ram_cpu_ratio = 1024
+    min_ram_cpu_ratio = 1
     min_secgroup_instance_ratio = 3
     min_ip_instance_ratio = 1
 
@@ -400,7 +400,7 @@ class SiteMonitor:
         # checks on quota
         if quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1) < self.min_ram_cpu_ratio:
             click.secho(
-                f"[-] WARNING: Less than {int(self.min_ram_cpu_ratio/1024)} GB RAM per available CPU",
+                f"[-] WARNING: Less than {self.min_ram_cpu_ratio} GB RAM per available CPU",
                 fg="yellow",
             )
         if (

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -383,7 +383,7 @@ class SiteMonitor:
             "ram",
             "floating-ips",
             "secgroup-rules",
-            "secgroup",
+            "secgroups",
         ]
         quota_info = {}
         for r in quota:

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -403,7 +403,10 @@ class SiteMonitor:
                 round(v["In Use"]/v["Limit"]*100)
             ))
         # checks on quota
-        if quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1) < self.min_ram_cpu_ratio:
+        if (
+            quota_info.get("ram (GB)").get("Limit", 1) / quota_info.get("cores").get("Limit", 1)
+            < self.min_ram_cpu_ratio:
+        ):
             click.secho(
                 f"[-] WARNING: Less than {self.min_ram_cpu_ratio} GB RAM per available CPU",
                 fg="yellow",


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

Right now information about quota only shows the quota limits:

```bash
[+] Quota information:
    ram (GB)       = 64
    instances      = 10
    cores          = 24
    floating-ips   = 2
    secgroup-rules = 100
```

With the changes in this PR, information about quotas includes both limits and actual usage:

```bash
[+] Quota information:
    ram (GB)       = Limit:  64, Used:  12 (19%)
    instances      = Limit:  10, Used:   3 (30%)
    cores          = Limit:  24, Used:   8 (33%)
    floating-ips   = Limit:   2, Used:   2 (100%)
    secgroup-rules = Limit: 100, Used:  28 (28%)
    secgroups      = Limit:  10, Used:   6 (60%)
```

This is useful to check how each `<vo, site>` is currently being utilized.

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :**
