### PR TITLE
List unused floating IPs, security groups, and volumes

### DIFF
--- a/fedcloud_vm_monitoring/cli.py
+++ b/fedcloud_vm_monitoring/cli.py
@@ -104,11 +104,13 @@ def main(
         )
         try:
             site_monitor.vm_monitor(delete)
+            if show_quotas:
+                click.echo("[+] Quota information:")
+                site_monitor.show_quotas()
+            site_monitor.check_unused_floating_ips()
+            site_monitor.check_unused_security_groups()
         except SiteMonitorException as e:
             click.echo(" ".join([click.style("ERROR:", fg="red"), str(e)]), err=True)
-        if show_quotas:
-            click.echo("[+] Quota information:")
-            site_monitor.show_quotas()
         # TODO: volumes, ips, should look for those older than X days
         #       and not attached to any VM for deletion
         # site_monitor.vol_monitor()

--- a/fedcloud_vm_monitoring/cli.py
+++ b/fedcloud_vm_monitoring/cli.py
@@ -109,9 +109,6 @@ def main(
                 site_monitor.show_quotas()
             site_monitor.check_unused_floating_ips()
             site_monitor.check_unused_security_groups()
+            site_monitor.check_unused_volumes()
         except SiteMonitorException as e:
             click.echo(" ".join([click.style("ERROR:", fg="red"), str(e)]), err=True)
-        # TODO: volumes, ips, should look for those older than X days
-        #       and not attached to any VM for deletion
-        # site_monitor.vol_monitor()
-        # site_monitor.ip_monitor()

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -367,6 +367,15 @@ class SiteMonitor:
                 if delete:
                     if click.confirm("Do you want to delete the instance?"):
                         self.delete_vm(vm)
+        self.check_unused_floating_ips()
+
+    def check_unused_floating_ips(self):
+        # get list of floating IPs created in <vo, site>
+        command = ("floating", "ip", "list", "--status", "DOWN")
+        result = self._run_command(command)
+        floating_ips_down = [fip["Floating IP Address"] for fip in result]
+        if len(floating_ips_down) > 0:
+            click.secho("[-] WARNING List of unused floating IPs: {}".format(floating_ips_down) ,fg="yellow")
 
     def vo_check(self):
         endpoint, _, _ = find_endpoint_and_project_id(self.site, self.vo)

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -165,9 +165,7 @@ class SiteMonitor:
                 else:
                     # check volumes attached
                     if len(attached_volumes) > 0:
-                        return self.get_vm_image_volume_show(
-                            attached_volumes[0]["id"]
-                        )
+                        return self.get_vm_image_volume_show(attached_volumes[0]["id"])
                     else:
                         return "image name not found"
             except SiteMonitorException:
@@ -316,7 +314,15 @@ class SiteMonitor:
                 )
             )
         output.append(
-            ("VM image", self.get_vm_image(vm["ID"], vm["Image Name"], vm["Image ID"], vm_info["attached_volumes"]))
+            (
+                "VM image",
+                self.get_vm_image(
+                    vm["ID"],
+                    vm["Image Name"],
+                    vm["Image ID"],
+                    vm_info["attached_volumes"],
+                ),
+            )
         )
         output.append(("created at", vm_info["created_at"]))
         output.append(("elapsed time", elapsed))

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -398,6 +398,26 @@ class SiteMonitor:
                 fg="yellow",
             )
 
+    def check_unused_volumes(self):
+        # get list of unused volumes in <vo, site>
+        command = ("volume", "list", "--status", "available")
+        result = self._run_command(command)
+        unused_capacity = 0
+        unused_volumes = []
+        for volume in result:
+            unused_capacity += volume["Size"]
+            unused_volumes.append(volume["Name"] if len(volume["Name"])>0 else volume["ID"])
+        if unused_capacity > 0:
+            click.secho(
+                "[-] WARNING: List of unused volumes: {}".format(unused_volumes),
+                fg="yellow",
+            )
+            click.secho(
+                "[-] WARNING: {} GB could be claimed back deleting unused volumes.".format(unused_capacity),
+                fg="yellow",
+            )
+
+
     def vo_check(self):
         endpoint, _, _ = find_endpoint_and_project_id(self.site, self.vo)
         return endpoint is not None

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -294,7 +294,7 @@ class SiteMonitor:
         sshd_version = self.get_sshd_version(vm_ips)
         created = parse(vm_info["created_at"])
         elapsed = self.now - created
-        secgroups = set([secgroup['name'] for secgroup in vm_info["security_groups"]])
+        secgroups = set([secgroup["name"] for secgroup in vm_info["security_groups"]])
         output = [
             ("instance name", vm["Name"]),
             ("instance id", vm["ID"]),
@@ -344,7 +344,12 @@ class SiteMonitor:
             output.append(
                 ("IM id", vm_info["properties"].get("eu.egi.cloud.orchestrator.id", ""))
             )
-        return {"ID": vm["ID"], "output": output, "elapsed": elapsed, "secgroups": secgroups}
+        return {
+            "ID": vm["ID"],
+            "output": output,
+            "elapsed": elapsed,
+            "secgroups": secgroups,
+        }
 
     def vm_monitor(self, delete=False):
         all_vms = self.get_vms()
@@ -378,12 +383,14 @@ class SiteMonitor:
         command = ("security", "group", "list", "--project", project_id)
         result = self._run_command(command)
         # until we get security group IDs attached to VMs
-        #all_secgroups = set([secgroup["ID"] for secgroup in result])
+        # all_secgroups = set([secgroup["ID"] for secgroup in result])
         all_secgroups = set([secgroup["Name"] for secgroup in result])
         unused_secgroups = all_secgroups - self.used_security_groups
         if len(unused_secgroups) > 0:
             click.secho(
-                "[-] WARNING: List of unused security groups: {}".format(unused_secgroups),
+                "[-] WARNING: List of unused security groups: {}".format(
+                    unused_secgroups
+                ),
                 fg="yellow",
             )
 
@@ -394,7 +401,9 @@ class SiteMonitor:
         floating_ips_down = [fip["Floating IP Address"] for fip in result]
         if len(floating_ips_down) > 0:
             click.secho(
-                "[-] WARNING: List of unused floating IPs: {}".format(floating_ips_down),
+                "[-] WARNING: List of unused floating IPs: {}".format(
+                    floating_ips_down
+                ),
                 fg="yellow",
             )
 
@@ -406,17 +415,20 @@ class SiteMonitor:
         unused_volumes = []
         for volume in result:
             unused_capacity += volume["Size"]
-            unused_volumes.append(volume["Name"] if len(volume["Name"])>0 else volume["ID"])
+            unused_volumes.append(
+                volume["Name"] if len(volume["Name"]) > 0 else volume["ID"]
+            )
         if unused_capacity > 0:
             click.secho(
                 "[-] WARNING: List of unused volumes: {}".format(unused_volumes),
                 fg="yellow",
             )
             click.secho(
-                "[-] WARNING: {} GB could be claimed back deleting unused volumes.".format(unused_capacity),
+                "[-] WARNING: {} GB could be claimed back deleting unused volumes.".format(
+                    unused_capacity
+                ),
                 fg="yellow",
             )
-
 
     def vo_check(self):
         endpoint, _, _ = find_endpoint_and_project_id(self.site, self.vo)

--- a/fedcloud_vm_monitoring/site_monitor.py
+++ b/fedcloud_vm_monitoring/site_monitor.py
@@ -375,7 +375,10 @@ class SiteMonitor:
         result = self._run_command(command)
         floating_ips_down = [fip["Floating IP Address"] for fip in result]
         if len(floating_ips_down) > 0:
-            click.secho("[-] WARNING List of unused floating IPs: {}".format(floating_ips_down) ,fg="yellow")
+            click.secho(
+                "[-] WARNING List of unused floating IPs: {}".format(floating_ips_down),
+                fg="yellow",
+            )
 
     def vo_check(self):
         endpoint, _, _ = find_endpoint_and_project_id(self.site, self.vo)


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Add code to list unused floating IPs, security groups, and volumes.

Related [discussion](https://lists.openstack.org/archives/list/openstack-discuss@lists.openstack.org/thread/24Y3FBJIAU6YJGMCX7UI6MOTUOH6MYQB/). Currently `openstack server show` list the security groups used by the VM using the security group name rather than the ID. Therefore a VM can have multiple security groups with the same name. This will cause issues identifying unused security groups. 

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :** https://github.com/EGI-Federation/fedcloud-vm-monitoring/issues/21
