### PR TITLE
Add option to show information by VO rather than per site

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,8 @@ Getting VMs information  [####################################]  100%
 
 ## fedcloud-sla-monitor
 
-`fedcloud-sla-monitor` checks the configuration of sites supporting SLAs. It
-compares the reported usage in the accounting portal and the information
-retrieved from the cloud-info-provider and reports any deviations.
+`fedcloud-sla-monitor` checks the configuration of sites supporting SLAs across
+GOCDB, AppDB, and the Accounting Portal, and reports any deviations.
 
 ### Requirements
 
@@ -215,15 +214,24 @@ retrieved from the cloud-info-provider and reports any deviations.
 
 ### Running the monitor
 
-```shell
-$ fedcloud-sla-monitor --help
-Usage: fedcloud-sla-monitor [OPTIONS]
+Without optional arguments, the monitor will show information about the SLA
+per site:
 
-Options:
-  --site TEXT         Site to check
-  --user-cert TEXT    User certificate (for GOCDB queries)  [required]
-  --vo-map-file TEXT  SLA-VO mapping file
-  --help              Show this message and exit.
+```shell
+$ fedcloud-sla-monitor --user-cert /path/to/x509.pem
+```
+
+The monitoring can be restricted to a specific site as follows:
+
+```shell
+$ fedcloud-sla-monitor --site SITE-NAME --user-cert /path/to/x509.pem
+```
+
+Additionally, rather than per site it is also possible to show SLA information
+per Virtual Organization:
+
+```shell
+$ fedcloud-sla-monitor --vo vo.name.eu --user-cert /path/to/x509.pem
 ```
 
 ## Useful links

--- a/README.md
+++ b/README.md
@@ -218,20 +218,20 @@ Without optional arguments, the monitor will show information about the SLA
 per site:
 
 ```shell
-$ fedcloud-sla-monitor --user-cert /path/to/x509.pem
+fedcloud-sla-monitor --user-cert /path/to/x509.pem
 ```
 
 The monitoring can be restricted to a specific site as follows:
 
 ```shell
-$ fedcloud-sla-monitor --site SITE-NAME --user-cert /path/to/x509.pem
+fedcloud-sla-monitor --site SITE-NAME --user-cert /path/to/x509.pem
 ```
 
 Additionally, rather than per site it is also possible to show SLA information
 per Virtual Organization:
 
 ```shell
-$ fedcloud-sla-monitor --vo vo.name.eu --user-cert /path/to/x509.pem
+fedcloud-sla-monitor --vo vo.name.eu --user-cert /path/to/x509.pem
 ```
 
 ## Useful links

--- a/README.md
+++ b/README.md
@@ -214,21 +214,21 @@ GOCDB, AppDB, and the Accounting Portal, and reports any deviations.
 
 ### Running the monitor
 
-Without optional arguments, the monitor will show information about the SLA
-per site:
+Without optional arguments the command will show information about the SLA
+across all sites:
 
 ```shell
 fedcloud-sla-monitor --user-cert /path/to/x509.pem
 ```
 
-The monitoring can be restricted to a specific site as follows:
+The monitoring can be restricted to a specific site as well:
 
 ```shell
 fedcloud-sla-monitor --site SITE-NAME --user-cert /path/to/x509.pem
 ```
 
-Additionally, rather than per site it is also possible to show SLA information
-per Virtual Organization:
+Additionally, it is also possible to show SLA information
+per Virtual Organization instead:
 
 ```shell
 fedcloud-sla-monitor --vo vo.name.eu --user-cert /path/to/x509.pem

--- a/fedcloud_monitoring_tools/accounting.py
+++ b/fedcloud_monitoring_tools/accounting.py
@@ -63,22 +63,24 @@ class Accounting:
             self._get_accounting_data()
         for col in self._data:
             if col["id"] == "ylegend":
-                return [vo for vo in col.values() if vo != 'ylegend' and vo != 'id']
+                return [vo for vo in col.values() if vo != "ylegend" and vo != "id"]
 
     def accounting_all_vos(self):
         active_VOs = {}
         for vo in self.all_vos():
             active_VOs[vo] = {}
             for i in self._data:
-                if i["id"] != 'Total' and \
-                   i["id"] != 'Percent' and \
-                   i["id"] != 'var' and \
-                   i["id"] != 'xlegend' and \
-                   i["id"] != 'ylegend' and \
-                   vo in i and \
-                   i[vo] is not None and \
-                   float(i[vo]) > 0.0:
-                   # loop over all sites having > 0 CPUh for this VO
+                if (
+                    i["id"] != "Total"
+                    and i["id"] != "Percent"
+                    and i["id"] != "var"
+                    and i["id"] != "xlegend"
+                    and i["id"] != "ylegend"
+                    and vo in i
+                    and i[vo] is not None
+                    and float(i[vo]) > 0.0
+                ):
+                    # loop over all sites having > 0 CPUh for this VO
                     site = i["id"]
                     cpuh = float(i[vo])
                     active_VOs[vo][site] = cpuh

--- a/fedcloud_monitoring_tools/accounting.py
+++ b/fedcloud_monitoring_tools/accounting.py
@@ -5,6 +5,7 @@ import numbers
 
 import httpx
 
+ACCOUNTING_DAYS = 90
 ACCOUNTING_URL = "https://accounting.egi.eu/"
 SITE_VO_ACCOUNTING = (
     "cloud/sum_elap_processors/SITE/VO/"
@@ -16,11 +17,12 @@ SITE_VO_ACCOUNTING = (
 class Accounting:
     def __init__(self):
         self._data = {}
+        self.days = ACCOUNTING_DAYS
 
     def _get_accounting_data(self):
         """Gets accounting data for sites / vos over the last 90 days"""
         today = datetime.date.today()
-        start = today - datetime.timedelta(days=90)
+        start = today - datetime.timedelta(days=self.days)
         url = ACCOUNTING_URL + SITE_VO_ACCOUNTING.format(
             start_year=start.year,
             start_month=start.month,
@@ -55,3 +57,33 @@ class Accounting:
             if col["id"] == "xlegend":
                 return [site[1] for site in col.items() if site[0] != "id"]
         return []
+
+    def all_vos(self):
+        if not self._data:
+            self._get_accounting_data()
+        for col in self._data:
+            if col["id"] == "ylegend":
+                return [vo for vo in col.values() if vo != 'ylegend' and vo != 'id']
+
+    def accounting_all_vos(self):
+        active_VOs = {}
+        for vo in self.all_vos():
+            active_VOs[vo] = {}
+            for i in self._data:
+                if i["id"] != 'Total' and \
+                   i["id"] != 'Percent' and \
+                   i["id"] != 'var' and \
+                   i["id"] != 'xlegend' and \
+                   i["id"] != 'ylegend' and \
+                   vo in i and \
+                   i[vo] is not None and \
+                   float(i[vo]) > 0.0:
+                   # loop over all sites having > 0 CPUh for this VO
+                    site = i["id"]
+                    cpuh = float(i[vo])
+                    active_VOs[vo][site] = cpuh
+            # it may happen that the VO doesn't have accounting after all
+            if len(active_VOs[vo]) == 0:
+                active_VOs.pop(vo)
+
+        return active_VOs

--- a/fedcloud_monitoring_tools/appdb.py
+++ b/fedcloud_monitoring_tools/appdb.py
@@ -61,7 +61,7 @@ class AppDB:
         return [i["VO"] for i in data]
 
     def all_vos(self):
-        r = requests.get(restful_url + "vos/")
+        r = requests.get(self.restful_url + "vos/")
         r.raise_for_status()
         result = []
         for vo in xmltodict.parse(r.text)["appdb:appdb"]["vo:vo"]:

--- a/fedcloud_monitoring_tools/appdb.py
+++ b/fedcloud_monitoring_tools/appdb.py
@@ -1,6 +1,7 @@
 """AppDB queries"""
 
 import requests
+import xmltodict
 
 sites_supporting_vo_query = """
 {
@@ -27,6 +28,7 @@ vos_in_site_query = """
 
 class AppDB:
     graphql_url = "https://is.appdb.egi.eu/graphql"
+    restful_url = "https://appdb-pi.egi.eu/rest/1.0/"
 
     def __init__(self):
         self.sites = {}
@@ -57,3 +59,11 @@ class AppDB:
         else:
             return []
         return [i["VO"] for i in data]
+
+    def all_vos(self):
+        r = requests.get(restful_url + "vos/")
+        r.raise_for_status()
+        result = []
+        for vo in xmltodict.parse(r.text)['appdb:appdb']['vo:vo']:
+            result.append(vo['@name'])
+        return result

--- a/fedcloud_monitoring_tools/appdb.py
+++ b/fedcloud_monitoring_tools/appdb.py
@@ -64,6 +64,6 @@ class AppDB:
         r = requests.get(restful_url + "vos/")
         r.raise_for_status()
         result = []
-        for vo in xmltodict.parse(r.text)['appdb:appdb']['vo:vo']:
-            result.append(vo['@name'])
+        for vo in xmltodict.parse(r.text)["appdb:appdb"]["vo:vo"]:
+            result.append(vo["@name"])
         return result

--- a/fedcloud_monitoring_tools/data/vos.yaml
+++ b/fedcloud_monitoring_tools/data/vos.yaml
@@ -136,8 +136,6 @@ OIPUB:
   - vo.oipub.com
 DECIDO:
   - vo.decido-project.eu
-AI4PUBLICPOLICY:
-  - vo.ai4publicpolicy.eu
 PSMA:
   - vo.radiotracers4psma.eu
 EUREKA3D:

--- a/fedcloud_monitoring_tools/data/vos.yaml
+++ b/fedcloud_monitoring_tools/data/vos.yaml
@@ -64,7 +64,7 @@ OPERAS:
   - vo.operas-eu.org
 DEEP:
   - deep-hybrid-datacloud.eu
-POLICYCLOUD:
+AI4PUBLICPOLICY:
   - vo.ai4publicpolicy.eu
 CSCALE:
   - aquamonitor.c-scale.eu
@@ -144,3 +144,5 @@ EUREKA3D:
   - culturalheritage.vo.egi.eu
 NEURODESK:
   - vo.neurodesk.eu
+EUROARGO:
+  - vo.euro-argo.eu

--- a/fedcloud_monitoring_tools/goc.py
+++ b/fedcloud_monitoring_tools/goc.py
@@ -48,7 +48,7 @@ class GOCDB:
                 # All nova endpoints in the service group do not support all VOs.
                 # Therefore, a special value is added to be treated accordingly.
                 for vo in vos:
-                    sites_per_vo[vo] = ['sla-group-with-multiple-vos']
+                    sites_per_vo[vo] = ["sla-group-with-multiple-vos"]
                 continue
             elif vos is None:
                 # This SLA service group does not have a VO associated, skipping

--- a/fedcloud_monitoring_tools/operations_portal.py
+++ b/fedcloud_monitoring_tools/operations_portal.py
@@ -4,7 +4,6 @@ import requests
 
 
 class OpsPortal:
-
     def __init__(self):
         self.vo_list = []
 

--- a/fedcloud_monitoring_tools/operations_portal.py
+++ b/fedcloud_monitoring_tools/operations_portal.py
@@ -1,0 +1,16 @@
+"""Operations Portal queries"""
+
+import requests
+import xmltodict
+
+class OpsPortal:
+
+    def __init__(self):
+        self.vo_list = []
+
+    def get_vo_list(self):
+        if len(self.vo_list) == 0:
+            r = requests.get("http://cclavoisier01.in2p3.fr:8080/lavoisier/VoList?accept=json")
+            r.raise_for_status()
+            self.vo_list = [vo['name'] for vo in r.json()['data']]
+        return self.vo_list

--- a/fedcloud_monitoring_tools/operations_portal.py
+++ b/fedcloud_monitoring_tools/operations_portal.py
@@ -1,7 +1,7 @@
 """Operations Portal queries"""
 
 import requests
-import xmltodict
+
 
 class OpsPortal:
 
@@ -10,7 +10,9 @@ class OpsPortal:
 
     def get_vo_list(self):
         if len(self.vo_list) == 0:
-            r = requests.get("http://cclavoisier01.in2p3.fr:8080/lavoisier/VoList?accept=json")
+            r = requests.get(
+                "http://cclavoisier01.in2p3.fr:8080/lavoisier/VoList?accept=json"
+            )
             r.raise_for_status()
-            self.vo_list = [vo['name'] for vo in r.json()['data']]
+            self.vo_list = [vo["name"] for vo in r.json()["data"]]
         return self.vo_list

--- a/fedcloud_monitoring_tools/sla_monitor_cli.py
+++ b/fedcloud_monitoring_tools/sla_monitor_cli.py
@@ -52,6 +52,7 @@ def check_site_slas(site, acct, appdb, goc, gocdb_sites):
         click.echo(f"[W] {site} has no configuration for ops")
     click.echo()
 
+
 def vo_in_map(vo, vo_map):
     flat_list = []
     for i in vo_map.values():
@@ -59,41 +60,47 @@ def vo_in_map(vo, vo_map):
             flat_list += i
     return vo in flat_list
 
+
 def check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo):
     if not vo_in_map(vo, vo_map):
-        click.secho("[ERR] VO {} not found in the map file provided".format(vo),
-                    fg="red", bold=True
-                   )
+        click.secho(
+            "[ERR] VO {} not found in the map file provided".format(vo),
+            fg="red",
+            bold=True,
+        )
         return
-    all_vos_acct  = acct.accounting_all_vos()
+    all_vos_acct = acct.accounting_all_vos()
     if vo not in all_vos_acct:
-        click.secho("[ERR] VO {} not found in Accounting Portal".format(vo),
-                    fg="red", bold=True
-                   )
+        click.secho(
+            "[ERR] VO {} not found in Accounting Portal".format(vo), fg="red", bold=True
+        )
         return
     all_vos_gocdb = goc.get_sites_vo(user_cert, vo_map)
     if vo not in all_vos_gocdb:
-        click.secho("[ERR] VO {} not found in GOCDB".format(vo),
-                    fg="red", bold=True
-                   )
+        click.secho("[ERR] VO {} not found in GOCDB".format(vo), fg="red", bold=True)
         return
     sites_gocdb = sorted(all_vos_gocdb[vo])
-    sites_acct  = sorted([provider for provider in all_vos_acct[vo]])
+    sites_acct = sorted([provider for provider in all_vos_acct[vo]])
     sites_appdb = sorted(appdb.get_sites_for_vo(vo))
     if sites_gocdb == sites_appdb == sites_acct:
-        click.secho("[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_gocdb),
-                    fg="green", bold=True
-                   )
-    elif 'sla-group-with-multiple-vos' in sites_gocdb and \
-         sites_appdb == sites_acct:
-        click.secho("[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_appdb),
-                    fg="green", bold=True
-                   )
+        click.secho(
+            "[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_gocdb),
+            fg="green",
+            bold=True,
+        )
+    elif "sla-group-with-multiple-vos" in sites_gocdb and sites_appdb == sites_acct:
+        click.secho(
+            "[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_appdb),
+            fg="green",
+            bold=True,
+        )
 
     else:
-        click.secho("[W] VO {}. Uncertain list of sites supporting the VO!".format(vo),
-                    fg="yellow", bold=True
-                   )
+        click.secho(
+            "[W] VO {}. Uncertain list of sites supporting the VO!".format(vo),
+            fg="yellow",
+            bold=True,
+        )
         click.echo("Sites in GOCDB: {}".format(sites_gocdb))
         click.echo("Sites in AppDB: {}".format(sites_appdb))
         click.echo("Sites in Accounting Portal: {}".format(sites_acct))

--- a/fedcloud_monitoring_tools/sla_monitor_cli.py
+++ b/fedcloud_monitoring_tools/sla_monitor_cli.py
@@ -7,6 +7,7 @@ import yaml
 from fedcloud_monitoring_tools.accounting import Accounting
 from fedcloud_monitoring_tools.appdb import AppDB
 from fedcloud_monitoring_tools.goc import GOCDB
+from fedcloud_monitoring_tools.operations_portal import OpsPortal
 
 
 def check_site_slas(site, acct, appdb, goc, gocdb_sites):
@@ -61,7 +62,7 @@ def vo_in_map(vo, vo_map):
     return vo in flat_list
 
 
-def check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo):
+def check_vo_sla(acct, appdb, goc, ops_portal, user_cert, vo_map, vo):
     if not vo_in_map(vo, vo_map):
         click.secho(
             "[ERR] VO {} not found in the map file provided".format(vo),
@@ -73,6 +74,12 @@ def check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo):
     if vo not in all_vos_acct:
         click.secho(
             "[ERR] VO {} not found in Accounting Portal".format(vo), fg="red", bold=True
+        )
+        return
+    all_vos_ops_portal = ops_portal.get_vo_list()
+    if vo not in all_vos_ops_portal:
+        click.secho(
+            "[ERR] VO {} not found in Operations Portal".format(vo), fg="red", bold=True
         )
         return
     all_vos_gocdb = goc.get_sites_vo(user_cert, vo_map)
@@ -132,10 +139,10 @@ def main(
     acct = Accounting()
     goc = GOCDB()
     appdb = AppDB()
-    # should we also check VOs in operations portal?
+    ops_portal = OpsPortal()
 
     if vo:
-        check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo)
+        check_vo_sla(acct, appdb, goc, ops_portal, user_cert, vo_map, vo)
     else:
         gocdb_sites = goc.get_sites_slas(user_cert, vo_map)
         if site:

--- a/fedcloud_monitoring_tools/sla_monitor_cli.py
+++ b/fedcloud_monitoring_tools/sla_monitor_cli.py
@@ -9,14 +9,14 @@ from fedcloud_monitoring_tools.appdb import AppDB
 from fedcloud_monitoring_tools.goc import GOCDB
 
 
-def check_site_slas(site, site_slas, goc, acct, appdb):
-    click.secho(f"[-] Checking site {site}", fg="blue", bold=True)
+def check_site_slas(site, acct, appdb, goc, gocdb_sites):
     sla_vos = set()
     appdb_vos = set(appdb.get_vo_for_site(site))
-    if site not in site_slas:
+    click.secho(f"[-] Checking site {site}", fg="blue", bold=True)
+    if site not in gocdb_sites:
         click.echo(f"[I] {site} is not present in any SLA")
     else:
-        for sla_name, sla in site_slas[site].items():
+        for sla_name, sla in gocdb_sites[site].items():
             click.echo(f"Information for SLA {sla_name}")
             sla_vos = sla_vos.union(sla["vos"])
             accounted_vos = sla["vos"].intersection(acct.site_vos(site))
@@ -52,13 +52,65 @@ def check_site_slas(site, site_slas, goc, acct, appdb):
         click.echo(f"[W] {site} has no configuration for ops")
     click.echo()
 
+def vo_in_map(vo, vo_map):
+    flat_list = []
+    for i in vo_map.values():
+        if i is not None:
+            flat_list += i
+    return vo in flat_list
+
+def check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo):
+    if not vo_in_map(vo, vo_map):
+        click.secho("[ERR] VO {} not found in the map file provided".format(vo),
+                    fg="red", bold=True
+                   )
+        return
+    all_vos_acct  = acct.accounting_all_vos()
+    if vo not in all_vos_acct:
+        click.secho("[ERR] VO {} not found in Accounting Portal".format(vo),
+                    fg="red", bold=True
+                   )
+        return
+    all_vos_gocdb = goc.get_sites_vo(user_cert, vo_map)
+    if vo not in all_vos_gocdb:
+        click.secho("[ERR] VO {} not found in GOCDB".format(vo),
+                    fg="red", bold=True
+                   )
+        return
+    sites_gocdb = sorted(all_vos_gocdb[vo])
+    sites_acct  = sorted([provider for provider in all_vos_acct[vo]])
+    sites_appdb = sorted(appdb.get_sites_for_vo(vo))
+    if sites_gocdb == sites_appdb == sites_acct:
+        click.secho("[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_gocdb),
+                    fg="green", bold=True
+                   )
+    elif 'sla-group-with-multiple-vos' in sites_gocdb and \
+         sites_appdb == sites_acct:
+        click.secho("[OK] VO {}. The sites supporting the VO are: {}".format(vo, sites_appdb),
+                    fg="green", bold=True
+                   )
+
+    else:
+        click.secho("[W] VO {}. Uncertain list of sites supporting the VO!".format(vo),
+                    fg="yellow", bold=True
+                   )
+        click.echo("Sites in GOCDB: {}".format(sites_gocdb))
+        click.echo("Sites in AppDB: {}".format(sites_appdb))
+        click.echo("Sites in Accounting Portal: {}".format(sites_acct))
+    click.echo("Accounting data per provider in the last {} days:".format(acct.days))
+    for provider in all_vos_acct[vo]:
+        click.echo("Site: {}, CPUh: {}".format(provider, all_vos_acct[vo][provider]))
+    click.echo()
+
 
 @click.command()
 @click.option("--site", help="Site to check")
+@click.option("--vo", help="Monitor SLAs per VO")
 @click.option("--user-cert", required=True, help="User certificate (for GOCDB queries)")
 @click.option("--vo-map-file", help="SLA-VO mapping file")
 def main(
     site,
+    vo,
     user_cert,
     vo_map_file,
 ):
@@ -73,10 +125,14 @@ def main(
     acct = Accounting()
     goc = GOCDB()
     appdb = AppDB()
-    slas = goc.get_sites_slas(user_cert, vo_map)
+    # should we also check VOs in operations portal?
 
-    if site:
-        check_site_slas(site, slas, goc, acct, appdb)
+    if vo:
+        check_vo_sla(acct, appdb, goc, user_cert, vo_map, vo)
     else:
-        for site in acct.all_sites():
-            check_site_slas(site, slas, goc, acct, appdb)
+        gocdb_sites = goc.get_sites_slas(user_cert, vo_map)
+        if site:
+            check_site_slas(site, acct, appdb, goc, gocdb_sites)
+        else:
+            for site in acct.all_sites():
+                check_site_slas(site, acct, appdb, goc, gocdb_sites)


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary

Currently `fedcloud-sla-monitor` shows per-site information for SLAs.

This PR adds the necessary changes to display the same information per-VO instead.

---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :**
